### PR TITLE
Fix the issue where the geolocation loading state is not reset.

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -479,7 +479,9 @@ const Geosuggest = React.createClass({
 
           // Pass formatted address to userInput
           _this.setState({
-            userInput: latlng.formattedAddress
+            userInput: latlng.formattedAddress,
+            disabled: false,
+            className: _this.props.className
           });
 
           // Trigger select if suggest object is passed


### PR DESCRIPTION
- Set className to default prop value when reverseGeocode is called.
- Set locality input to disabled:false.
